### PR TITLE
Fix UsersService 'country' parameter validation

### DIFF
--- a/YourGamesList.Api.UnitTests/Services/Users/UsersServiceTests.cs
+++ b/YourGamesList.Api.UnitTests/Services/Users/UsersServiceTests.cs
@@ -142,6 +142,45 @@ public class UsersServiceTests : BaseTest
     }
 
     [Test]
+    [TestCase("")]
+    [TestCase(null)]
+    public async Task UpdateUser_SuccessfulScenario_WithCountrySetToEmptyOrNull_UpdatesUserAndReturnsId_QUICK(string? country)
+    {
+        //ARRANGE
+        var parameters = _fixture.Build<UserUpdateParameters>()
+            .With(x => x.Country, country)
+            .With(x => x.Description, "ebebe")
+            .With(x => x.DateOfBirth, (DateTimeOffset?) null)
+            .WithAutoProperties()
+            .Create();
+        var userId = parameters.UserInformation.UserId;
+        var time = _fixture.Create<DateTimeOffset>();
+        _timeProvider.GetUtcNow().Returns(time);
+        var user = new User()
+        {
+            Id = userId,
+            Username = parameters.UserInformation.Username,
+            PasswordHash = _fixture.Create<string>(),
+            CreatedDate = DateTime.UtcNow,
+            Salt = _fixture.Create<byte[]>()
+        };
+        var users = new List<User>() { user };
+        _yglDbContextBuilder.WithUserDbSet(users);
+        var userDto = _fixture.Create<UserDto>();
+        _yglDatabaseAndDtoMapper.Map(Arg.Is<User>(u => u.Id == userId)).Returns(userDto);
+        _countriesService.ValidateThreeLetterIsoCode(parameters.Country).Returns(false);
+
+        var usersService = new UsersService(_logger, _dbContextFactory, _yglDatabaseAndDtoMapper, _countriesService, _timeProvider);
+
+        //ACT
+        var result = await usersService.UpdateUser(parameters);
+
+        //ASSERT
+        //QUICK - just check if there is no error
+        Assert.That(result.IsSuccess, Is.True);
+    }
+
+    [Test]
     public async Task UpdateUser_OnValidationError_WrongCountry_ReturnsUserUpdateWrongInputDataError()
     {
         //ARRANGE

--- a/YourGamesList.Api/Services/Users/UsersService.cs
+++ b/YourGamesList.Api/Services/Users/UsersService.cs
@@ -82,7 +82,7 @@ public class UsersService : IUsersService
 
     private bool ValidateUserUpdateParameters(UserUpdateParameters parameters)
     {
-        if (!_countriesService.ValidateThreeLetterIsoCode(parameters.Country))
+        if (!string.IsNullOrWhiteSpace(parameters.Country) && !_countriesService.ValidateThreeLetterIsoCode(parameters.Country))
         {
             LogValidationError("wrong country name");
             return false;


### PR DESCRIPTION
UsersService validation for 'country' parameter fixed (empty strings caused validation to fail in the past)